### PR TITLE
adapt to the new configfs API

### DIFF
--- a/driver/common.h
+++ b/driver/common.h
@@ -32,76 +32,76 @@
 
 
 struct group_node {
-    struct config_group group;
+	struct config_group group;
 };
 
 static inline struct group_node *to_node(struct config_item *item)
 {
-    return item ? container_of(to_config_group(item), struct group_node,
-        group) : NULL;
+	return item ? container_of(to_config_group(item), struct group_node,
+		group) : NULL;
 }
 
 #define IKGT_CONFIGFS_TO_CONTAINER(__s)  \
-    static inline struct __s  *to_##__s(struct config_item *item) \
+	static inline struct __s  *to_##__s(struct config_item *item) \
 { \
-    return item ? container_of(item, struct __s, item) : NULL; \
+	return item ? container_of(item, struct __s, item) : NULL; \
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 
-#define IKGT_CONFIGFS_ATTR_RO(__s, __name)      \
-    CONFIGFS_ATTR_RO(__s##_, __name);
+#define IKGT_CONFIGFS_ATTR_RO(__s, __name)		\
+	CONFIGFS_ATTR_RO(__s##_, __name);
 
-#define IKGT_CONFIGFS_ATTR_RW(__s, __name)              \
-    CONFIGFS_ATTR(__s##_, __name);
+#define IKGT_CONFIGFS_ATTR_RW(__s, __name)				\
+	CONFIGFS_ATTR(__s##_, __name);
 
-#define IKGT_UINT32_SHOW(__s, __name)   \
-    static ssize_t __s##_##__name##_show(struct config_item *item,  \
-    char *page) \
-{   \
-    return sprintf(page, "%u\n", to_##__s(item)->__name);   \
+#define IKGT_UINT32_SHOW(__s, __name)	\
+	static ssize_t __s##_##__name##_show(struct config_item *item,	\
+	char *page) \
+{	\
+	return sprintf(page, "%u\n", to_##__s(item)->__name);	\
 }
 
-#define IKGT_UINT32_HEX_SHOW(__s, __name)   \
-    static ssize_t __s##_##__name##_show(struct config_item *item, \
-    char *page) \
-{   \
-    return sprintf(page, "0x%X\n", to_##__s(item)->__name); \
+#define IKGT_UINT32_HEX_SHOW(__s, __name)	\
+	static ssize_t __s##_##__name##_show(struct config_item *item, \
+	char *page) \
+{	\
+	return sprintf(page, "0x%X\n", to_##__s(item)->__name); \
 }
 
-#define IKGT_UINT32_STORE(__s, __name)  \
-    static ssize_t __s##_##__name##_store(struct config_item *item, \
-    const char *page, \
-    size_t count) \
+#define IKGT_UINT32_STORE(__s, __name)	\
+	static ssize_t __s##_##__name##_store(struct config_item *item, \
+	const char *page, \
+	size_t count) \
 { \
-    unsigned long value;\
-    \
-    if (kstrtoul(page, 0, &value)) \
-    return -EINVAL; \
-    to_##__s(item)->__name = value;             \
-    \
-    return count; \
+	unsigned long value;\
+	\
+	if (kstrtoul(page, 0, &value)) \
+	return -EINVAL; \
+	to_##__s(item)->__name = value;	\
+	\
+	return count; \
 }
 
-#define IKGT_ULONG_HEX_SHOW(__s, __name)    \
-    static ssize_t __s##_##__name##_show(struct config_item *item,  \
-    char *page) \
-{   \
-    return sprintf(page, "0x%lX\n", to_##__s(item)->__name);    \
+#define IKGT_ULONG_HEX_SHOW(__s, __name)  \
+	static ssize_t __s##_##__name##_show(struct config_item *item, \
+	char *page) \
+{	\
+	return sprintf(page, "0x%lX\n", to_##__s(item)->__name); \
 }
 
-#define IKGT_ULONG_HEX_STORE(__s, __name)   \
-    static ssize_t __s##_##__name##_store(struct config_item *item, \
-    const char *page, \
-    size_t count) \
+#define IKGT_ULONG_HEX_STORE(__s, __name) \
+	static ssize_t __s##_##__name##_store(struct config_item *item, \
+	const char *page, \
+	size_t count) \
 { \
-    unsigned long value;\
-    \
-    if (kstrtoul(page, 16, &value)) \
-    return -EINVAL; \
-    to_##__s(item)->__name = value;             \
-    \
-    return count; \
+	unsigned long value;\
+	\
+	if (kstrtoul(page, 16, &value)) \
+	return -EINVAL; \
+	to_##__s(item)->__name = value; \
+	\
+	return count; \
 }
 
 #else
@@ -110,58 +110,54 @@ static inline struct group_node *to_node(struct config_item *item)
 	static struct __s##_attribute __s##_attr_##__name =	\
 		__CONFIGFS_ATTR_RO(_name, __s##_show_##__name);
 
-#define IKGT_CONFIGFS_ATTR_RW(__s, __name)								\
-	static struct __s##_attribute __s##_attr_##__name =					\
+#define IKGT_CONFIGFS_ATTR_RW(__s, __name) \
+	static struct __s##_attribute __s##_attr_##__name =	\
 		__CONFIGFS_ATTR(__name, S_IRUGO | S_IWUSR, __s##_show_##__name, \
 						__s##_store_##__name)
 
-#define IKGT_UINT32_SHOW(__s, __name)						\
-	static ssize_t __s##_show_##__name(struct __s *item,    \
-									   char *page)			\
-	{														\
-		return sprintf(page, "%u\n", item->__name);			\
+#define IKGT_UINT32_SHOW(__s, __name) \
+	static ssize_t __s##_show_##__name(struct __s *item, \
+									   char *page) \
+	{ \
+		return sprintf(page, "%u\n", item->__name);	\
 	}
 
-#define IKGT_UINT32_HEX_SHOW(__s, __name)					\
-	static ssize_t __s##_show_##__name(struct __s *item,    \
-									   char *page)          \
-	{                                                       \
-		return sprintf(page, "0x%X\n", item->__name);		\
+#define IKGT_UINT32_HEX_SHOW(__s, __name) \
+	static ssize_t __s##_show_##__name(struct __s *item, \
+									   char *page) \
+	{ \
+		return sprintf(page, "0x%X\n", item->__name); \
 	}
 
-#define IKGT_UINT32_STORE(__s, __name)						\
-	static ssize_t __s##_store_##__name(struct __s *item,   \
-										const char *page,   \
-										size_t count)       \
-	{                                                       \
-		unsigned long value;								\
-															\
-		if (kstrtoul(page, 0, &value))						\
-			return -EINVAL;									\
-		item->__name = value;								\
-															\
-		return count;										\
+#define IKGT_UINT32_STORE(__s, __name) \
+	static ssize_t __s##_store_##__name(struct __s *item, \
+										const char *page, \
+										size_t count) \
+	{ \
+		unsigned long value; \
+		if (kstrtoul(page, 0, &value)) \
+			return -EINVAL; \
+		item->__name = value; \
+		return count; \
 	}
 
-#define IKGT_ULONG_HEX_SHOW(__s, __name)					\
-	static ssize_t __s##_show_##__name(struct __s *item,    \
-									   char *page)          \
-	{                                                       \
-		return sprintf(page, "0x%lX\n", item->__name);		\
+#define IKGT_ULONG_HEX_SHOW(__s, __name) \
+	static ssize_t __s##_show_##__name(struct __s *item, \
+									   char *page) \
+	{ \
+		return sprintf(page, "0x%lX\n", item->__name); \
 	}
 
-#define IKGT_ULONG_HEX_STORE(__s, __name)					\
-	static ssize_t __s##_store_##__name(struct __s *item,   \
-										const char *page,   \
-										size_t count)       \
-	{                                                       \
-		unsigned long value;								\
-															\
-		if (kstrtoul(page, 16, &value))						\
-			return -EINVAL;									\
-		item->__name = value;								\
-															\
-		return count;										\
+#define IKGT_ULONG_HEX_STORE(__s, __name) \
+	static ssize_t __s##_store_##__name(struct __s *item, \
+										const char *page, \
+										size_t count) \
+	{ \
+		unsigned long value; \
+		if (kstrtoul(page, 16, &value))	\
+			return -EINVAL;	\
+		item->__name = value; \
+		return count; \
 	}
 #endif
 
@@ -171,33 +167,33 @@ typedef uint8_t policy_action_w;
 typedef uint8_t policy_action_x;
 
 struct cr0_cfg {
-    struct config_item item;
-    bool enable;
-    bool locked;
-    policy_action_w write;
-    unsigned long sticky_value;
+	struct config_item item;
+	bool enable;
+	bool locked;
+	policy_action_w write;
+	unsigned long sticky_value;
 };
 
 struct cr4_cfg {
-    struct config_item item;
-    bool enable;
-    bool locked;
-    policy_action_w write;
-    unsigned long sticky_value;
+	struct config_item item;
+	bool enable;
+	bool locked;
+	policy_action_w write;
+	unsigned long sticky_value;
 };
 
 struct msr_cfg {
-    struct config_item item;
-    bool enable;
-    bool locked;
-    policy_action_w write;
-    unsigned long sticky_value;
+	struct config_item item;
+	bool enable;
+	bool locked;
+	policy_action_w write;
+	unsigned long sticky_value;
 };
 
 typedef struct _name_value_map {
-    const char *name;
-    unsigned long value;
-    uint32_t res_id;
+	const char *name;
+	unsigned long value;
+	uint32_t res_id;
 } name_value_map;
 
 

--- a/driver/common.h
+++ b/driver/common.h
@@ -19,6 +19,7 @@
 #include <linux/configfs.h>
 #include <linux/slab.h>
 #include <linux/stat.h>
+#include <linux/version.h>
 
 #define DEBUG
 
@@ -31,108 +32,172 @@
 
 
 struct group_node {
-	struct config_group group;
+    struct config_group group;
 };
 
 static inline struct group_node *to_node(struct config_item *item)
 {
-	return item ? container_of(to_config_group(item), struct group_node,
-		group) : NULL;
+    return item ? container_of(to_config_group(item), struct group_node,
+        group) : NULL;
 }
 
 #define IKGT_CONFIGFS_TO_CONTAINER(__s)  \
-	static inline struct __s  *to_##__s(struct config_item *item) \
+    static inline struct __s  *to_##__s(struct config_item *item) \
 { \
-	return item ? container_of(item, struct __s, item) : NULL; \
+    return item ? container_of(item, struct __s, item) : NULL; \
 }
 
-#define IKGT_CONFIGFS_ATTR_RO(__s, __name)	\
-	CONFIGFS_ATTR_RO(__s##_, __name);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 
-#define IKGT_CONFIGFS_ATTR_RW(__s, __name)				\
-	CONFIGFS_ATTR(__s##_, __name);
+#define IKGT_CONFIGFS_ATTR_RO(__s, __name)      \
+    CONFIGFS_ATTR_RO(__s##_, __name);
 
-#define IKGT_UINT32_SHOW(__s, __name)	\
-	static ssize_t __s##_##__name##_show(struct config_item *item,	\
-	char *page) \
-{	\
-	return sprintf(page, "%u\n", to_##__s(item)->__name);	\
+#define IKGT_CONFIGFS_ATTR_RW(__s, __name)              \
+    CONFIGFS_ATTR(__s##_, __name);
+
+#define IKGT_UINT32_SHOW(__s, __name)   \
+    static ssize_t __s##_##__name##_show(struct config_item *item,  \
+    char *page) \
+{   \
+    return sprintf(page, "%u\n", to_##__s(item)->__name);   \
 }
 
-#define IKGT_UINT32_HEX_SHOW(__s, __name)	\
-	static ssize_t __s##_##__name##_show(struct config_item *item, \
-	char *page) \
-{	\
-	return sprintf(page, "0x%X\n", to_##__s(item)->__name);	\
+#define IKGT_UINT32_HEX_SHOW(__s, __name)   \
+    static ssize_t __s##_##__name##_show(struct config_item *item, \
+    char *page) \
+{   \
+    return sprintf(page, "0x%X\n", to_##__s(item)->__name); \
 }
 
-#define IKGT_UINT32_STORE(__s, __name)	\
-	static ssize_t __s##_##__name##_store(struct config_item *item, \
-	const char *page, \
-	size_t count) \
+#define IKGT_UINT32_STORE(__s, __name)  \
+    static ssize_t __s##_##__name##_store(struct config_item *item, \
+    const char *page, \
+    size_t count) \
 { \
-	unsigned long value;\
-	\
-	if (kstrtoul(page, 0, &value)) \
-	return -EINVAL; \
-	to_##__s(item)->__name = value;				\
-	\
-	return count; \
+    unsigned long value;\
+    \
+    if (kstrtoul(page, 0, &value)) \
+    return -EINVAL; \
+    to_##__s(item)->__name = value;             \
+    \
+    return count; \
 }
 
-#define IKGT_ULONG_HEX_SHOW(__s, __name)	\
-	static ssize_t __s##_##__name##_show(struct config_item *item,	\
-	char *page) \
-{	\
-	return sprintf(page, "0x%lX\n", to_##__s(item)->__name);	\
+#define IKGT_ULONG_HEX_SHOW(__s, __name)    \
+    static ssize_t __s##_##__name##_show(struct config_item *item,  \
+    char *page) \
+{   \
+    return sprintf(page, "0x%lX\n", to_##__s(item)->__name);    \
 }
 
-#define IKGT_ULONG_HEX_STORE(__s, __name)	\
-	static ssize_t __s##_##__name##_store(struct config_item *item,	\
-	const char *page, \
-	size_t count) \
+#define IKGT_ULONG_HEX_STORE(__s, __name)   \
+    static ssize_t __s##_##__name##_store(struct config_item *item, \
+    const char *page, \
+    size_t count) \
 { \
-	unsigned long value;\
-	\
-	if (kstrtoul(page, 16, &value)) \
-	return -EINVAL; \
-	to_##__s(item)->__name = value;				\
-	\
-	return count; \
+    unsigned long value;\
+    \
+    if (kstrtoul(page, 16, &value)) \
+    return -EINVAL; \
+    to_##__s(item)->__name = value;             \
+    \
+    return count; \
 }
+
+#else
+
+#define IKGT_CONFIGFS_ATTR_RO(__s, __name)				\
+	static struct __s##_attribute __s##_attr_##__name =	\
+		__CONFIGFS_ATTR_RO(_name, __s##_show_##__name);
+
+#define IKGT_CONFIGFS_ATTR_RW(__s, __name)								\
+	static struct __s##_attribute __s##_attr_##__name =					\
+		__CONFIGFS_ATTR(__name, S_IRUGO | S_IWUSR, __s##_show_##__name, \
+						__s##_store_##__name)
+
+#define IKGT_UINT32_SHOW(__s, __name)						\
+	static ssize_t __s##_show_##__name(struct __s *item,    \
+									   char *page)			\
+	{														\
+		return sprintf(page, "%u\n", item->__name);			\
+	}
+
+#define IKGT_UINT32_HEX_SHOW(__s, __name)					\
+	static ssize_t __s##_show_##__name(struct __s *item,    \
+									   char *page)          \
+	{                                                       \
+		return sprintf(page, "0x%X\n", item->__name);		\
+	}
+
+#define IKGT_UINT32_STORE(__s, __name)						\
+	static ssize_t __s##_store_##__name(struct __s *item,   \
+										const char *page,   \
+										size_t count)       \
+	{                                                       \
+		unsigned long value;								\
+															\
+		if (kstrtoul(page, 0, &value))						\
+			return -EINVAL;									\
+		item->__name = value;								\
+															\
+		return count;										\
+	}
+
+#define IKGT_ULONG_HEX_SHOW(__s, __name)					\
+	static ssize_t __s##_show_##__name(struct __s *item,    \
+									   char *page)          \
+	{                                                       \
+		return sprintf(page, "0x%lX\n", item->__name);		\
+	}
+
+#define IKGT_ULONG_HEX_STORE(__s, __name)					\
+	static ssize_t __s##_store_##__name(struct __s *item,   \
+										const char *page,   \
+										size_t count)       \
+	{                                                       \
+		unsigned long value;								\
+															\
+		if (kstrtoul(page, 16, &value))						\
+			return -EINVAL;									\
+		item->__name = value;								\
+															\
+		return count;										\
+	}
+#endif
+
 
 typedef uint8_t policy_action_r;
 typedef uint8_t policy_action_w;
 typedef uint8_t policy_action_x;
 
 struct cr0_cfg {
-	struct config_item item;
-	bool enable;
-	bool locked;
-	policy_action_w write;
-	unsigned long sticky_value;
+    struct config_item item;
+    bool enable;
+    bool locked;
+    policy_action_w write;
+    unsigned long sticky_value;
 };
 
 struct cr4_cfg {
-	struct config_item item;
-	bool enable;
-	bool locked;
-	policy_action_w write;
-	unsigned long sticky_value;
+    struct config_item item;
+    bool enable;
+    bool locked;
+    policy_action_w write;
+    unsigned long sticky_value;
 };
 
 struct msr_cfg {
-	struct config_item item;
-	bool enable;
-	bool locked;
-	policy_action_w write;
-	unsigned long sticky_value;
+    struct config_item item;
+    bool enable;
+    bool locked;
+    policy_action_w write;
+    unsigned long sticky_value;
 };
 
 typedef struct _name_value_map {
-	const char *name;
-	unsigned long value;
-	uint32_t res_id;
+    const char *name;
+    unsigned long value;
+    uint32_t res_id;
 } name_value_map;
 
 

--- a/driver/common.h
+++ b/driver/common.h
@@ -47,29 +47,27 @@ static inline struct group_node *to_node(struct config_item *item)
 }
 
 #define IKGT_CONFIGFS_ATTR_RO(__s, __name)	\
-	static struct __s##_attribute __s##_attr_##__name = __CONFIGFS_ATTR_RO(_name, __s##_show_##__name);
+	CONFIGFS_ATTR_RO(__s##_, __name);
 
 #define IKGT_CONFIGFS_ATTR_RW(__s, __name)				\
-	static struct __s##_attribute __s##_attr_##__name =	\
-	__CONFIGFS_ATTR(__name, S_IRUGO | S_IWUSR, __s##_show_##__name, \
-	__s##_store_##__name)
+	CONFIGFS_ATTR(__s##_, __name);
 
 #define IKGT_UINT32_SHOW(__s, __name)	\
-	static ssize_t __s##_show_##__name(struct __s *item, \
+	static ssize_t __s##_##__name##_show(struct config_item *item,	\
 	char *page) \
 {	\
-	return sprintf(page, "%u\n", item->__name); \
+	return sprintf(page, "%u\n", to_##__s(item)->__name);	\
 }
 
 #define IKGT_UINT32_HEX_SHOW(__s, __name)	\
-	static ssize_t __s##_show_##__name(struct __s *item, \
+	static ssize_t __s##_##__name##_show(struct config_item *item, \
 	char *page) \
 {	\
-	return sprintf(page, "0x%X\n", item->__name); \
+	return sprintf(page, "0x%X\n", to_##__s(item)->__name);	\
 }
 
 #define IKGT_UINT32_STORE(__s, __name)	\
-	static ssize_t __s##_store_##__name(struct __s *item, \
+	static ssize_t __s##_##__name##_store(struct config_item *item, \
 	const char *page, \
 	size_t count) \
 { \
@@ -77,20 +75,20 @@ static inline struct group_node *to_node(struct config_item *item)
 	\
 	if (kstrtoul(page, 0, &value)) \
 	return -EINVAL; \
-	item->__name = value; \
+	to_##__s(item)->__name = value;				\
 	\
 	return count; \
 }
 
 #define IKGT_ULONG_HEX_SHOW(__s, __name)	\
-	static ssize_t __s##_show_##__name(struct __s *item, \
+	static ssize_t __s##_##__name##_show(struct config_item *item,	\
 	char *page) \
 {	\
-	return sprintf(page, "0x%lX\n", item->__name); \
+	return sprintf(page, "0x%lX\n", to_##__s(item)->__name);	\
 }
 
 #define IKGT_ULONG_HEX_STORE(__s, __name)	\
-	static ssize_t __s##_store_##__name(struct __s *item, \
+	static ssize_t __s##_##__name##_store(struct config_item *item,	\
 	const char *page, \
 	size_t count) \
 { \
@@ -98,7 +96,7 @@ static inline struct group_node *to_node(struct config_item *item)
 	\
 	if (kstrtoul(page, 16, &value)) \
 	return -EINVAL; \
-	item->__name = value; \
+	to_##__s(item)->__name = value;				\
 	\
 	return count; \
 }

--- a/driver/configfs_setup.c
+++ b/driver/configfs_setup.c
@@ -55,16 +55,16 @@ static struct config_group *group_children_make_group(struct config_group *group
 
 	if (strcasecmp(name, GROUP_NAME_CR0) == 0) {
 		config_group_init_type_name(&cfg->group, name,
-									get_cr0_children_type());
+			get_cr0_children_type());
 	} else if (strcasecmp(name, GROUP_NAME_CR4) == 0) {
 		config_group_init_type_name(&cfg->group, name,
-									get_cr4_children_type());
+			get_cr4_children_type());
 	} else if (strcasecmp(name, GROUP_NAME_MSR) == 0) {
 		config_group_init_type_name(&cfg->group, name,
-									get_msr_children_type());
+			get_msr_children_type());
 	} else if (strcasecmp(name, GROUP_NAME_LOG) == 0) {
 		config_group_init_type_name(&cfg->group, name,
-									get_log_children_type());
+			get_log_children_type());
 	}
 
 	return &cfg->group;
@@ -90,7 +90,7 @@ static struct configfs_attribute group_children_attr_description = {
 	.ca_name	= "description",
 	.ca_mode	= S_IRUGO,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-	.show       = group_children_description_show
+	.show		= group_children_description_show
 #endif
 };
 
@@ -106,22 +106,22 @@ static struct configfs_item_operations group_children_item_ops = {
 #endif
 
 static struct configfs_group_operations group_children_group_ops = {
-	.make_group	= group_children_make_group,
+	.make_group = group_children_make_group,
 };
 
 static struct config_item_type group_children_type = {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
-	.ct_item_ops	= &group_children_item_ops,
+	.ct_item_ops  = &group_children_item_ops,
 #endif
 	.ct_group_ops = &group_children_group_ops,
-	.ct_attrs	= group_children_attrs,
-	.ct_owner	= THIS_MODULE,
+	.ct_attrs     = group_children_attrs,
+	.ct_owner     = THIS_MODULE,
 };
 
 static struct configfs_subsystem group_children_subsys = {
 	.su_group			= {
 		.cg_item		= {
-			.ci_namebuf	= DRIVER_NAME,
+			.ci_namebuf = DRIVER_NAME,
 			.ci_type	= &group_children_type,
 		},
 	},
@@ -168,3 +168,4 @@ void uninit_configfs_setup(void)
 	for (i = 0; configfs_subsys[i]; i++)
 		configfs_unregister_subsystem(configfs_subsys[i]);
 }
+

--- a/driver/configfs_setup.c
+++ b/driver/configfs_setup.c
@@ -55,35 +55,43 @@ static struct config_group *group_children_make_group(struct config_group *group
 
 	if (strcasecmp(name, GROUP_NAME_CR0) == 0) {
 		config_group_init_type_name(&cfg->group, name,
-			get_cr0_children_type());
+									get_cr0_children_type());
 	} else if (strcasecmp(name, GROUP_NAME_CR4) == 0) {
 		config_group_init_type_name(&cfg->group, name,
-			get_cr4_children_type());
+									get_cr4_children_type());
 	} else if (strcasecmp(name, GROUP_NAME_MSR) == 0) {
 		config_group_init_type_name(&cfg->group, name,
-			get_msr_children_type());
+									get_msr_children_type());
 	} else if (strcasecmp(name, GROUP_NAME_LOG) == 0) {
 		config_group_init_type_name(&cfg->group, name,
-			get_log_children_type());
+									get_log_children_type());
 	}
 
 	return &cfg->group;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static ssize_t group_children_description_show(struct config_item *item,
 											   char *page)
+#else
+static ssize_t group_children_attr_show(struct config_item *item,
+										struct configfs_attribute *attr,
+										char *page)
+#endif
 {
-		return sprintf(page,
-					   DRIVER_NAME"\n"
-					   "These file subsystem allows to create groups for various cpu assets.\n"
-					   "These groups can be cr0, cr4, msr, log, etc.\n");
+	return sprintf(page,
+				   DRIVER_NAME"\n"
+				   "These file subsystem allows to create groups for various cpu assets.\n"
+				   "These groups can be cr0, cr4, msr, log, etc.\n");
 }
 
 static struct configfs_attribute group_children_attr_description = {
 	.ca_owner	= THIS_MODULE,
 	.ca_name	= "description",
 	.ca_mode	= S_IRUGO,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 	.show       = group_children_description_show
+#endif
 };
 
 static struct configfs_attribute *group_children_attrs[] = {
@@ -91,11 +99,20 @@ static struct configfs_attribute *group_children_attrs[] = {
 	NULL,
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
+static struct configfs_item_operations group_children_item_ops = {
+	.show_attribute = group_children_attr_show,
+};
+#endif
+
 static struct configfs_group_operations group_children_group_ops = {
 	.make_group	= group_children_make_group,
 };
 
 static struct config_item_type group_children_type = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
+	.ct_item_ops	= &group_children_item_ops,
+#endif
 	.ct_group_ops = &group_children_group_ops,
 	.ct_attrs	= group_children_attrs,
 	.ct_owner	= THIS_MODULE,

--- a/driver/configfs_setup.c
+++ b/driver/configfs_setup.c
@@ -70,10 +70,20 @@ static struct config_group *group_children_make_group(struct config_group *group
 	return &cfg->group;
 }
 
+static ssize_t group_children_description_show(struct config_item *item,
+											   char *page)
+{
+		return sprintf(page,
+					   DRIVER_NAME"\n"
+					   "These file subsystem allows to create groups for various cpu assets.\n"
+					   "These groups can be cr0, cr4, msr, log, etc.\n");
+}
+
 static struct configfs_attribute group_children_attr_description = {
 	.ca_owner	= THIS_MODULE,
 	.ca_name	= "description",
 	.ca_mode	= S_IRUGO,
+	.show       = group_children_description_show
 };
 
 static struct configfs_attribute *group_children_attrs[] = {
@@ -81,28 +91,12 @@ static struct configfs_attribute *group_children_attrs[] = {
 	NULL,
 };
 
-static ssize_t group_children_attr_show(struct config_item *item,
-struct configfs_attribute *attr,
-	char *page)
-{
-	return sprintf(page,
-		DRIVER_NAME"\n"
-		"These file subsystem allows to create groups for various cpu assets.\n"
-		"These groups can be cr0, cr4, msr, log, etc.\n");
-}
-
-static struct configfs_item_operations group_children_item_ops = {
-	.show_attribute = group_children_attr_show,
-};
-
-
 static struct configfs_group_operations group_children_group_ops = {
 	.make_group	= group_children_make_group,
 };
 
 static struct config_item_type group_children_type = {
-	.ct_item_ops	= &group_children_item_ops,
-	.ct_group_ops	= &group_children_group_ops,
+	.ct_group_ops = &group_children_group_ops,
 	.ct_attrs	= group_children_attrs,
 	.ct_owner	= THIS_MODULE,
 };
@@ -157,4 +151,3 @@ void uninit_configfs_setup(void)
 	for (i = 0; configfs_subsys[i]; i++)
 		configfs_unregister_subsystem(configfs_subsys[i]);
 }
-

--- a/driver/cr0.c
+++ b/driver/cr0.c
@@ -111,7 +111,7 @@ static int valid_cr0_attr(const char *name)
 }
 
 /*-------------------------------------------------------*
-*  Function      : policy_set_cr0()
+*  Function: policy_set_cr0()
 *  Purpose: send the CR0 policy settings to handler
 *  Parameters: cr0_cfg, enable
 *  Return: true=success, false=failure
@@ -192,8 +192,8 @@ static ssize_t cr0_cfg_sticky_value_store(struct config_item *item,
 	struct cr0_cfg *cr0_cfg = to_cr0_cfg(item);
 #else
 static ssize_t cr0_cfg_store_sticky_value(struct cr0_cfg *cr0_cfg,
-								   const char *page,
-								   size_t count)
+										  const char *page,
+										  size_t count)
 {
 #endif
 	unsigned long value;
@@ -214,7 +214,7 @@ static ssize_t cr0_cfg_enable_store(struct config_item *item,
 									const char *page,
 									size_t count)
 {
-    struct cr0_cfg *cr0_cfg = to_cr0_cfg(item);
+	struct cr0_cfg *cr0_cfg = to_cr0_cfg(item);
 #else
 static ssize_t cr0_cfg_store_enable(struct cr0_cfg *cr0_cfg,
 									const char *page,
@@ -250,7 +250,7 @@ static void cr0_cfg_release(struct config_item *item)
 }
 
 static struct configfs_item_operations cr0_cfg_ops = {
-	.release		 = cr0_cfg_release,
+	.release         = cr0_cfg_release,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
 	.show_attribute	 = cr0_cfg_attr_show,
 	.store_attribute = cr0_cfg_attr_store,
@@ -290,7 +290,7 @@ static struct config_item *cr0_make_item(struct config_group *group,
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static ssize_t cr0_children_description_show(struct config_item *item,
-									  char *page)
+											 char *page)
 
 #else
 static ssize_t cr0_children_attr_show(struct config_item *item,
@@ -299,10 +299,10 @@ static ssize_t cr0_children_attr_show(struct config_item *item,
 #endif
 {
 	return sprintf(page,
-		"CR0\n"
-		"\n"
-		"Used in protected mode to control operations .  \n"
-		"items are readable and writable.\n");
+			"CR0\n"
+			"\n"
+			"Used in protected mode to control operations .	 \n"
+			"items are readable and writable.\n");
 }
 
 static struct configfs_attribute cr0_children_attr_description = {
@@ -310,7 +310,7 @@ static struct configfs_attribute cr0_children_attr_description = {
 	.ca_name	= "description",
 	.ca_mode	= S_IRUGO,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-	.show       = cr0_children_description_show,
+	.show	= cr0_children_description_show,
 #endif
 };
 

--- a/driver/cr0.c
+++ b/driver/cr0.c
@@ -13,6 +13,7 @@
 */
 
 #include <linux/module.h>
+#include <linux/version.h>
 
 #include "ikgt_api.h"
 #include "common.h"
@@ -35,6 +36,7 @@ static name_value_map cr0_bits[] = {
 	{}
 };
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static ssize_t cr0_cfg_enable_store(struct config_item *item,
 									const char *page,
 									size_t count);
@@ -46,9 +48,27 @@ static ssize_t cr0_cfg_write_store(struct config_item *item,
 static ssize_t cr0_cfg_sticky_value_store(struct config_item *item,
 										  const char *page,
 										  size_t count);
+#else
+static ssize_t cr0_cfg_store_enable(struct cr0_cfg *cr0_cfg,
+									const char *page,
+									size_t count);
+
+static ssize_t cr0_cfg_store_write(struct cr0_cfg *cr0_cfg,
+								   const char *page,
+								   size_t count);
+
+static ssize_t cr0_cfg_store_sticky_value(struct cr0_cfg *cr0_cfg,
+										  const char *page,
+										  size_t count);
+#endif
 
 /* to_cr0_cfg() function */
 IKGT_CONFIGFS_TO_CONTAINER(cr0_cfg);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
+/* define attribute structure */
+CONFIGFS_ATTR_STRUCT(cr0_cfg);
+#endif
 
 /* item operations */
 IKGT_UINT32_SHOW(cr0_cfg, enable);
@@ -61,12 +81,21 @@ IKGT_CONFIGFS_ATTR_RW(cr0_cfg, write);
 IKGT_CONFIGFS_ATTR_RW(cr0_cfg, sticky_value);
 
 static struct configfs_attribute *cr0_cfg_attrs[] = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 	&cr0_cfg_attr_enable,
 	&cr0_cfg_attr_write,
 	&cr0_cfg_attr_sticky_value,
+#else
+	&cr0_cfg_attr_enable.attr,
+	&cr0_cfg_attr_write.attr,
+	&cr0_cfg_attr_sticky_value.attr,
+#endif
 	NULL,
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
+CONFIGFS_ATTR_OPS(cr0_cfg);
+#endif
 
 static int valid_cr0_attr(const char *name)
 {
@@ -129,13 +158,19 @@ static bool policy_set_cr0(struct cr0_cfg *cr0_cfg, bool enable)
 	return (ret == SUCCESS)?true:false;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static ssize_t cr0_cfg_write_store(struct config_item *item,
 								   const char *page,
 								   size_t count)
 {
-	unsigned long value;
-
 	struct cr0_cfg *cr0_cfg = to_cr0_cfg(item);
+#else
+static ssize_t cr0_cfg_store_write(struct cr0_cfg *cr0_cfg,
+								   const char *page,
+								   size_t count)
+{
+#endif
+	unsigned long value;
 
 	if (cr0_cfg->locked)
 		return -EPERM;
@@ -148,13 +183,20 @@ static ssize_t cr0_cfg_write_store(struct config_item *item,
 	return count;
 }
 
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static ssize_t cr0_cfg_sticky_value_store(struct config_item *item,
 										  const char *page,
 										  size_t count)
 {
-	unsigned long value;
-
 	struct cr0_cfg *cr0_cfg = to_cr0_cfg(item);
+#else
+static ssize_t cr0_cfg_store_sticky_value(struct cr0_cfg *cr0_cfg,
+								   const char *page,
+								   size_t count)
+{
+#endif
+	unsigned long value;
 
 	if (cr0_cfg->locked)
 		return -EPERM;
@@ -167,14 +209,20 @@ static ssize_t cr0_cfg_sticky_value_store(struct config_item *item,
 	return count;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static ssize_t cr0_cfg_enable_store(struct config_item *item,
 									const char *page,
 									size_t count)
 {
+    struct cr0_cfg *cr0_cfg = to_cr0_cfg(item);
+#else
+static ssize_t cr0_cfg_store_enable(struct cr0_cfg *cr0_cfg,
+									const char *page,
+									size_t count)
+{
+#endif
 	unsigned long value;
 	bool ret = false;
-
-	struct cr0_cfg *cr0_cfg = to_cr0_cfg(item);
 
 	if (kstrtoul(page, 0, &value))
 		return -EINVAL;
@@ -202,7 +250,11 @@ static void cr0_cfg_release(struct config_item *item)
 }
 
 static struct configfs_item_operations cr0_cfg_ops = {
-	.release		= cr0_cfg_release,
+	.release		 = cr0_cfg_release,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
+	.show_attribute	 = cr0_cfg_attr_show,
+	.store_attribute = cr0_cfg_attr_store,
+#endif
 };
 
 static struct config_item_type cr0_cfg_type = {
@@ -236,21 +288,30 @@ static struct config_item *cr0_make_item(struct config_group *group,
 	return &cr0_cfg->item;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static ssize_t cr0_children_description_show(struct config_item *item,
 									  char *page)
+
+#else
+static ssize_t cr0_children_attr_show(struct config_item *item,
+									  struct configfs_attribute *attr,
+									  char *page)
+#endif
 {
-		return sprintf(page,
-					   "CR0\n"
-					   "\n"
-					   "Used in protected mode to control operations .  \n"
-					   "items are readable and writable.\n");
+	return sprintf(page,
+		"CR0\n"
+		"\n"
+		"Used in protected mode to control operations .  \n"
+		"items are readable and writable.\n");
 }
 
 static struct configfs_attribute cr0_children_attr_description = {
 	.ca_owner	= THIS_MODULE,
 	.ca_name	= "description",
 	.ca_mode	= S_IRUGO,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 	.show       = cr0_children_description_show,
+#endif
 };
 
 static struct configfs_attribute *cr0_children_attrs[] = {
@@ -266,6 +327,9 @@ static void cr0_children_release(struct config_item *item)
 
 static struct configfs_item_operations cr0_children_item_ops = {
 	.release	= cr0_children_release,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
+	.show_attribute = cr0_children_attr_show,
+#endif
 };
 
 static struct configfs_group_operations cr0_children_group_ops = {

--- a/driver/cr4.c
+++ b/driver/cr4.c
@@ -174,15 +174,15 @@ static ssize_t cr4_cfg_store_write(struct cr4_cfg *cr4_cfg,
 {
 #endif
 	unsigned long value;
-	
+
 	if (cr4_cfg->locked)
 		return -EPERM;
-	
+
 	if (kstrtoul(page, 0, &value))
 		return -EINVAL;
-	
+
 	cr4_cfg->write = value;
-	
+
 	return count;
 }
 
@@ -199,18 +199,18 @@ static ssize_t cr4_cfg_store_sticky_value(struct cr4_cfg *cr4_cfg,
 {
 #endif
 	unsigned long value;
-	
+
 	if (cr4_cfg->locked)
 		return -EPERM;
-	
+
 	if (kstrtoul(page, 0, &value))
 		return -EINVAL;
-	
+
 	cr4_cfg->sticky_value = value;
-	
+
 	return count;
 }
- 
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static ssize_t cr4_cfg_enable_store(struct config_item *item,
 											const char *page,
@@ -253,10 +253,10 @@ static void cr4_cfg_release(struct config_item *item)
 }
 
 static struct configfs_item_operations cr4_cfg_ops = {
-	 .release = cr4_cfg_release,
+	.release = cr4_cfg_release,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
-	 .show_attribute	 = cr4_cfg_attr_show,
-	 .store_attribute = cr4_cfg_attr_store,
+	.show_attribute	 = cr4_cfg_attr_show,
+	.store_attribute = cr4_cfg_attr_store,
 #endif
 };
 
@@ -265,8 +265,8 @@ static struct config_item_type cr4_cfg_type = {
 	.ct_attrs = cr4_cfg_attrs,
 	.ct_owner = THIS_MODULE,
 };
- 
- 
+
+
 static struct config_item *cr4_make_item(struct config_group *group,
 										 const char *name)
 {
@@ -278,18 +278,18 @@ static struct config_item *cr4_make_item(struct config_group *group,
 		PRINTK_ERROR("Invalid CR4 bit name\n");
 		return ERR_PTR(-EINVAL);
 	}
-	
+
 	cr4_cfg = kzalloc(sizeof(struct cr4_cfg), GFP_KERNEL);
 	if (!cr4_cfg) {
 		return ERR_PTR(-ENOMEM);
 	}
-	
+
 	config_item_init_type_name(&cr4_cfg->item, name,
-							   &cr4_cfg_type);
-	
+		&cr4_cfg_type);
+
 	return &cr4_cfg->item;
 }
- 
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static ssize_t cr4_children_description_show(struct config_item *item,
 											 char *page)
@@ -301,18 +301,18 @@ static ssize_t cr4_children_attr_show(struct config_item *item,
 #endif
 {
 	return sprintf(page,
-				   "CR4\n"
-				   "\n"
-				   "Used in protected mode to control operations .  \n"
-				   "items are readable and writable.\n");
+			"CR4\n"
+			"\n"
+			"Used in protected mode to control operations .	\n"
+			"items are readable and writable.\n");
 }
- 
+
 static struct configfs_attribute cr4_children_attr_description = {
 	.ca_owner	= THIS_MODULE,
 	.ca_name	= "description",
 	.ca_mode	= S_IRUGO,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-	.show       = cr4_children_description_show,
+	.show		= cr4_children_description_show,
 #endif
 };
 
@@ -343,7 +343,7 @@ static struct config_item_type cr4_children_type = {
 	.ct_attrs	= cr4_children_attrs,
 	.ct_owner	= THIS_MODULE,
 };
- 
+
 struct config_item_type *get_cr4_children_type(void)
 {
 	return &cr4_children_type;

--- a/driver/log.c
+++ b/driver/log.c
@@ -43,7 +43,7 @@ static ssize_t log_children_attr_show(struct config_item *item,
 									  char *page)
 #endif
 {
-		return dump_log(page);
+	return dump_log(page);
 }
 
 
@@ -52,7 +52,7 @@ static struct configfs_attribute log_children_attr_description = {
 	.ca_name	= "log.txt",
 	.ca_mode	= S_IRUGO,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-	.show       = log_children_show,
+	.show		= log_children_show,
 #endif
 };
 

--- a/driver/log.c
+++ b/driver/log.c
@@ -33,11 +33,18 @@ static log_entry_t *log_data_gva;
 #define MAX_ELLIPSIS_SIZE  4
 #define MAX_CONFIGFS_PAGE_SIZE  (PAGE_4KB - MAX_SENTINEL_SIZE - MAX_ELLIPSIS_SIZE - 1)
 
+static int dump_log(char *configfs_page);
+static ssize_t log_children_show(struct config_item *item, char *page)
+{
+		return dump_log(page);
+}
+
 
 static struct configfs_attribute log_children_attr_description = {
 	.ca_owner	= THIS_MODULE,
 	.ca_name	= "log.txt",
 	.ca_mode	= S_IRUGO,
+	.show       = log_children_show,
 };
 
 static struct configfs_attribute *log_children_attrs[] = {
@@ -45,13 +52,6 @@ static struct configfs_attribute *log_children_attrs[] = {
 	NULL,
 };
 
-static int dump_log(char *configfs_page);
-static ssize_t log_children_attr_show(struct config_item *item,
-struct configfs_attribute *attr,
-	char *page)
-{
-	return dump_log(page);
-}
 
 static void log_children_release(struct config_item *item)
 {
@@ -60,7 +60,6 @@ static void log_children_release(struct config_item *item)
 
 static struct configfs_item_operations log_children_item_ops = {
 	.release	= log_children_release,
-	.show_attribute = log_children_attr_show,
 };
 
 static struct config_item_type log_children_type = {

--- a/driver/log.c
+++ b/driver/log.c
@@ -13,6 +13,7 @@
 */
 
 #include <linux/module.h>
+#include <linux/version.h>
 
 #include "common.h"
 #include "policy_common.h"
@@ -34,7 +35,13 @@ static log_entry_t *log_data_gva;
 #define MAX_CONFIGFS_PAGE_SIZE  (PAGE_4KB - MAX_SENTINEL_SIZE - MAX_ELLIPSIS_SIZE - 1)
 
 static int dump_log(char *configfs_page);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static ssize_t log_children_show(struct config_item *item, char *page)
+#else
+static ssize_t log_children_attr_show(struct config_item *item,
+									  struct configfs_attribute *attr,
+									  char *page)
+#endif
 {
 		return dump_log(page);
 }
@@ -44,7 +51,9 @@ static struct configfs_attribute log_children_attr_description = {
 	.ca_owner	= THIS_MODULE,
 	.ca_name	= "log.txt",
 	.ca_mode	= S_IRUGO,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 	.show       = log_children_show,
+#endif
 };
 
 static struct configfs_attribute *log_children_attrs[] = {
@@ -60,6 +69,9 @@ static void log_children_release(struct config_item *item)
 
 static struct configfs_item_operations log_children_item_ops = {
 	.release	= log_children_release,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
+	.show_attribute = log_children_attr_show,
+#endif
 };
 
 static struct config_item_type log_children_type = {
@@ -226,4 +238,3 @@ void test_log(void)
 	PRINTK_INFO("After: p[size-1]=%c\n", p[size - 1]);
 }
 #endif
-

--- a/driver/msr.c
+++ b/driver/msr.c
@@ -174,11 +174,10 @@ static ssize_t msr_cfg_sticky_value_store(struct config_item *item,
 										  size_t count)
 {
 	struct msr_cfg *msr_cfg = to_msr_cfg(item);
-
 #else
 static ssize_t msr_cfg_store_sticky_value(struct msr_cfg *msr_cfg,
-								   const char *page,
-								   size_t count)
+										  const char *page,
+										  size_t count)
 {
 #endif
 	unsigned long value;
@@ -200,7 +199,7 @@ static ssize_t msr_cfg_enable_store(struct config_item *item,
 									size_t count)
 {
 
-  struct msr_cfg *msr_cfg = to_msr_cfg(item);
+	struct msr_cfg *msr_cfg = to_msr_cfg(item);
 #else
 static ssize_t msr_cfg_store_enable(struct msr_cfg *msr_cfg,
 									const char *page,
@@ -236,7 +235,7 @@ static void msr_cfg_release(struct config_item *item)
 }
 
 static struct configfs_item_operations msr_cfg_ops = {
-	.release		= msr_cfg_release,
+	 .release	     = msr_cfg_release,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
 	.show_attribute	 = msr_cfg_attr_show,
 	.store_attribute = msr_cfg_attr_store,
@@ -266,7 +265,7 @@ static struct config_item *msr_make_item(struct config_group *group,
 	}
 
 	config_item_init_type_name(&msr_cfg->item, name,
-		&msr_cfg_type);
+							   &msr_cfg_type);
 
 	return &msr_cfg->item;
 }
@@ -282,11 +281,11 @@ static ssize_t msr_children_attr_show(struct config_item *item,
 									  char *page)
 #endif
 {
-		return sprintf(page,
-					   "MSR\n"
-					   "\n"
-					   "Used in protected mode to control operations .  \n"
-					   "items are readable and writable.\n");
+	return sprintf(page,
+		       "MSR\n"
+		       "\n"
+		       "Used in protected mode to control operations .	\n"
+		       "items are readable and writable.\n");
 }
 
 static struct configfs_attribute msr_children_attr_description = {
@@ -294,7 +293,7 @@ static struct configfs_attribute msr_children_attr_description = {
 	.ca_name	= "description",
 	.ca_mode	= S_IRUGO,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-	.show       = msr_children_description_show,
+	.show		= msr_children_description_show,
 #endif
 };
 


### PR DESCRIPTION
configfs API changed in Linux 4.6 which causes the example driver to
break. This patch adapts the driver to the changes in the API.

Change-Id: If4e65d51c9d1791b71611b7d8a4206c01d72af19
